### PR TITLE
Add draft schedule

### DIFF
--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -3,15 +3,48 @@ title: Virtual Workshop Schedule
 nav_title: Schedule
 ---
 
-<!--See an example from a past virtual workshop here: https://github.com/AlexsLemonade/2020-may-training/wiki/Schedule --> 
+A preliminary schedule for the March 2022 CCDL Virtual Training Workshop appears below.
 
-| Time        | Topic                                          |
-|-------------|------------------------------------------------|
-| **Day 1**   | **Date** <br> [Module]()                      |
-| 12:00 PM    | Welcome, Introductions and Getting Started     <br>[Welcome Slides (PDF)](../slides/ Workshop_Introduction.pdf)|
-| 5:00        | End             |
-| **Day 2**   | **Date**  | 
-| **Day 3**   | **Date**  |               
-| **Day 4**   | **Date**  | 
-| **Day 5**   | **Date**  |     
-| 5:00        | Adjourn   |
+*Note: All times are [EDT (UTC−04:00)](https://www.timeanddate.com/time/zones/edt).*
+*Be aware that we transition(ed) to Daylight Saving Time on March 13, so relative times may have changed!*
+
+
+| Time        | Topic                             | Location |
+|-------------|--------------------------------------------|----------------|
+| **Day 1**   | **2022-03-14** <br> [_**Introduction to R and the Tidyverse**_](https://github.com/alexslemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/README.md)                      |
+| 12:00 PM    | Welcome, Introductions and Getting Started     | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 1:00 PM     | [Introduction to base R](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/01-intro_to_base_R.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
+| 2:30 PM     | [Introduction to ggplot2](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/02-intro_to_ggplot2.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 3:30 PM     | [Introduction to the tidyverse](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/03-intro_to_tidyverse.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 4:30        | Questions and introduction to the exercises | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
+|             | [Exercise: Introduction to R](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/exercise_02-intro_to_R.Rmd)| | 
+|             | [Consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
+| 5:00  PM    | End             |
+| **Day 2**   | **2022-03-15**  <br> [_**Introduction to Single-cell RNA-seq, Day 1**_](https://github.com/AlexsLemonade/training-modules/tree/master/scRNA-seq#readme) | 
+| 12:00 PM    | scRNA-seq: Introduction  | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 12:30 PM    | [scRNA-seq:  Quantification and general QC of tag-based data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/01-scRNA_quant_qc.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
+| 1:30 PM     | [scRNA-seq: Importing data and filtering cells](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/02-filtering_scRNA.nb.html)  | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 2:30 PM     | [scRNA-seq: Normalization of expression data](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/03-normalizing_scRNA.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 3:30 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
+|             | [Exercise: scRNA-seq quantification](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_01-scrna_quant.Rmd)
+|             | [Consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
+| 5:00  PM    | End             |
+| **Day 3**   | **2022-03-16**  <br> [_**Single-cell RNA-seq, Day 2**_](https://github.com/AlexsLemonade/training-modules/tree/master/scRNA-seq#readme) | 
+| 12:00 PM    | [scRNA-seq:  Dimension reduction & visualization](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/04-dimension_reduction_scRNA.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call)|
+| 1:30 PM     | [scRNA-seq: Clustering and marker identification](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/05-clustering_markers_scRNA.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 3:00 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
+|             | [Exercise: scRNA-seq clustering](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_02-scrna_clustering.Rmd)
+|             | [Consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
+| 5:00  PM    | End             |         
+| **Day 4**   | **2022-03-17**  <br> [_**Introduction to Pathway Analysis**_](https://github.com/AlexsLemonade/training-modules/tree/master/scRNA-seq#readme) | | 
+| 12:00 PM    | Introduction to Pathway Analysis |  Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 12:30 PM    | [Pathway analysis: Over-representation analysis](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/06-overrepresentation_analysis.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 2:00 PM     | [Pathway analysis: Gene Set Enrichment Analysis](https://htmlpreview.github.io/?https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/07-gene_set_enrichment_analysis.nb.html) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) | 
+| 3:00 PM     | Questions and introduction to the exercise | Zoom: [Breakout Rooms](../virtual-setup/zoom-procedures.md#using-zoom-breakout-rooms) |
+|             | [Exercise: scRNA-seq pathway analysis](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/scRNA-seq/exercise_03-scrna-seq_pathway.Rmd)
+|             | [Consultation session](workshop-structure.md#consultation-sessions) | [Slack channel](../virtual-setup/slack-procedures.md#general-use)|
+| 5:00 PM     | End || 
+| **Day 5**   | **2022-03-18**  <br> _**Consultation and Presentations**_ |     
+| 12:00 PM    | [Consultation session](workshop-structure.md#consultation-sessions)  | [Slack channel](../virtual-setup/slack-procedures.md#general-use) |
+| 2:30 PM     | [Participant presentations begin](workshop-structure.md#presentations) | Zoom: [Main Session](../virtual-setup/zoom-procedures.md#joining-a-zoom-call) |
+| 5:00 PM     | Adjourn   |


### PR DESCRIPTION
Note: stacked on #13

This PR adds a draft schedule, which is based on the schedule from 2021-November. I removed links to slides, but otherwise I expect the schedule to be the same.

I also added a cautionary note about time changes.

Please check that I got dates correct!

closes #7